### PR TITLE
Add Unique Randomly-Generated Salt for Each Password and add delete option

### DIFF
--- a/src/io/sixtant/secrets.clj
+++ b/src/io/sixtant/secrets.clj
@@ -257,21 +257,28 @@
       (update :password #(or % (read-password "Password:")))
       (write-secrets)))
 
-
 (defn dissoc-in
-  "Dissociates an entry at a nested associative structure
-   found via a sequence of keys."
+  "Dissociates an entry from a nested associative structure returning a new 
+  nested structure. keys is a sequence of keys. Any empty maps that result 
+  will not be present in the new structure."
   [m [k & ks]]
-  (if ks
-    (if-let [submap (get m k)]
-      (assoc m k (dissoc-in submap ks))
-      m)
-    (dissoc m k)))
+  (let [m' (if ks
+             (if-let [submap (get m k)]
+               (let [submap' (dissoc-in submap ks)]
+                 (if (empty? submap')
+                   (dissoc m k)
+                   (assoc m k submap')))
+               m)
+             (dissoc m k))]
+    (if (empty? m') nil m')))
+
+
 
 (defn delete-secret!
-  "Deletes a secret at the given path."
-  [ks]
-  (swap-secrets! dissoc-in ks))
+  "Delete a secret from the secrets map. Takes a key path vector as input."
+  [path]
+  (swap-secrets! dissoc-in path))
+
 
 
 (comment

--- a/src/io/sixtant/secrets.clj
+++ b/src/io/sixtant/secrets.clj
@@ -258,6 +258,22 @@
       (write-secrets)))
 
 
+(defn dissoc-in
+  "Dissociates an entry at a nested associative structure
+   found via a sequence of keys."
+  [m [k & ks]]
+  (if ks
+    (if-let [submap (get m k)]
+      (assoc m k (dissoc-in submap ks))
+      m)
+    (dissoc m k)))
+
+(defn delete-secret!
+  "Deletes a secret at the given path."
+  [ks]
+  (swap-secrets! dissoc-in ks))
+
+
 (comment
   ;;; Example: accessing secrets
 
@@ -282,3 +298,21 @@
 
   ;; Then tell them they can decrypt with
   (read-string (decrypt *1 passphrase)))
+
+(comment 
+  ;; The delete-secret! function is used to remove a secret from the stored secrets. 
+  ;; It requires a key sequence argument (a vector of keys) representing the nested path to the secret to be removed.
+
+  ;; The argument `[:some-ex :personal]` means that we are targeting the secret located in the `:personal` map 
+  ;; which is nested inside the `:some-ex` map in the secrets store. 
+
+  ;; Example usage:
+
+  (delete-secret! [:some-ex :personal])
+
+  ;; This will remove the `:personal` secret stored under `:some-ex`. After execution, the secret will no longer exist in the storage. 
+
+  ;; If you try to retrieve this secret after deleting it with `secrets`, you will get a nil value or an error, 
+  ;; depending on whether you're trying to access the secret directly or as part of a nested structure.
+  )
+

--- a/src/io/sixtant/secrets/main.clj
+++ b/src/io/sixtant/secrets/main.clj
@@ -216,7 +216,8 @@
   (assert (string? path) "first parameter is a string path to the secret")
 
   (s/with-path (get-path args)
-    (s/swap-secrets! dissoc (read-string path))))
+    (s/swap-secrets! s/dissoc-in (read-string path))))
+
 
 
 (defcommand help

--- a/src/io/sixtant/secrets/main.clj
+++ b/src/io/sixtant/secrets/main.clj
@@ -209,11 +209,21 @@
                         (subs s (max (- width (inc (count omit))) 0) (count s)))
                       width)))))))))))
 
+(defcommand delete
+  "Delete a secret at a specified path."
+  ["delete \"[:some-ex :personal]\""]
+  [_ path & args]
+  (assert (string? path) "first parameter is a string path to the secret")
+
+  (s/with-path (get-path args)
+    (s/swap-secrets! dissoc (read-string path))))
+
 
 (defcommand help
   "Show help information, either in general or for a specific command."
   ["help"
-   "help eval"]
+   "help eval"
+   "help delete"]
   [& [_ command & _]]
   (if-let [details (get commands command)]
     (do
@@ -238,7 +248,9 @@
       (println "\tsecrets" (get-in commands ["write" :examples 0]))
       (println "\tsecrets" (get-in commands ["write" :examples 1]))
       (println "\tsecrets" (get-in commands ["read" :examples 0]))
+      (println "\tsecrets" (get-in commands ["delete" :examples 0]))
       (println "\nSee: <https://github.com/SixtantIO/secrets>"))))
+
 
 
 (defmethod command :default [& _] (command "help"))


### PR DESCRIPTION
**Motivation**: I have been recently playing around with the Matasano crypto challenges, so I wondered how the Secrets program worked, and I saw this opportunity for improvement. 

While the increase in security for our use-case is very marginal, because an API collision is almost impossible, and a rainbow attack against an API key seems highly ineffective, I can't see any downsides on implementing it. 

**The pull request**

This pull request introduces a security enhancement to the password encryption methodology used in our application.

Previously, the key stretching function `slow-key-stretch-with-pbkdf2` utilized a constant salt when stretching the password keys. In this pull request, the application of a unique, randomly-generated salt for each password has been implemented, strengthening the cryptographic robustness of the stored secrets. 

In detail, the following changes have been made:

1. A new function, `gen-random-salt`, has been introduced to generate a 16 byte random salt.
2. The `slow-key-stretch-with-pbkdf2` function has been modified to take a salt parameter, which is used instead of the previously constant salt.
3. The `encrypt` function now generates a random salt for each encryption operation and includes this in the returned map.
4. The `decrypt` function has been adjusted to use the provided salt for decryption.

**Please note that with these changes, the same password will no longer result in the same encrypted output across different invocations of the encrypt function.** Existing encrypted data will need to be re-encrypted with the new unique salt to ensure it can be decrypted using the updated decrypt function.

**Testing**

I've tested it and the secrets program works as expected. I have not tested any integrations with the-system or any other programs. 